### PR TITLE
Packaging improvements

### DIFF
--- a/assembly/MANIFEST.MF
+++ b/assembly/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Vaadin-Package-Version: 1
+Vaadin-Addon: ${Vaadin-Addon}
+Vaadin-License-Title: ${Vaadin-License-Title}
+Implementation-Vendor: ${Implementation-Vendor}
+Implementation-Title: ${Implementation-Title}
+Implementation-Version: ${Implementation-Version}

--- a/assembly/assembly.xml
+++ b/assembly/assembly.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly
+	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	<id>addon</id>
+
+	<!-- Note: the base directory for this assembly descriptor is one of the 
+		license specific subprojects -->
+
+	<formats>
+		<format>zip</format>
+	</formats>
+
+	<!-- Do not use because we must put META-INF/MANIFEST.MF there. -->
+	<includeBaseDirectory>false</includeBaseDirectory>
+
+	<fileSets>
+		<fileSet>
+			<directory>..</directory>
+			<includes>
+				<include>LICENSE.txt</include>
+				<include>README.md</include>
+			</includes>
+		</fileSet>
+		<fileSet>
+			<directory>target</directory>
+			<outputDirectory></outputDirectory>
+			<includes>
+				<include>*.jar</include>
+                <include>*.pdf</include>
+			</includes>
+		</fileSet>
+	</fileSets>
+
+	<files>
+		<!-- This is vaadin.com/directory related manifest needed in the zip package -->
+		<file>
+			<source>assembly/MANIFEST.MF</source>
+			<outputDirectory>META-INF</outputDirectory>
+			<filtered>true</filtered>
+		</file>
+	</files>
+</assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,28 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.version>3.1.2.RELEASE</spring.version>
         <vaadin.version>7.1.0</vaadin.version>
+		
+        <!-- ZIP Manifest fields -->
+        <Implementation-Version>${project.version}</Implementation-Version>
+        <!-- Must not change this because of the Directory -->
+        <Implementation-Title>${project.name}</Implementation-Title>
+        <Implementation-Vendor>${project.organization.name}</Implementation-Vendor>
+        <Vaadin-License-Title>Apache License 2.0</Vaadin-License-Title>
+        <Vaadin-Addon>${artifactId}-${project.version}.jar</Vaadin-Addon>
     </properties>
+    
+    <scm>
+        <url>git://github.com/xpoft/spring-vaadin.git</url>
+        <connection>scm:git:git://github.com/xpoft/spring-vaadin.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com:/xpoft/spring-vaadin.git</developerConnection>
+        <tag>spring-vaadin-integration</tag>
+    </scm>
+
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/xpoft/spring-vaadin/issues</url>
+    </issueManagement>
+
 
     <dependencies>
         <!-- Logging -->
@@ -89,6 +110,8 @@
 
     <build>
         <plugins>
+			
+			
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.5.1</version>
@@ -105,6 +128,35 @@
                     </execution>
                 </executions>
             </plugin>
+			
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadoc</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+			
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
@@ -132,6 +184,26 @@
                     </instructions>
                 </configuration>
 
+            </plugin>
+			
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.2.1</version>
+                <configuration>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <descriptors>
+                        <descriptor>assembly/assembly.xml</descriptor>
+                    </descriptors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <phase>install</phase>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
- source and javadoc jars now built
- assembly:single target generates a zip file suitable for vaadin.com/directory to publish sources/javadocs
- add scm and issueManagement entries to pom.xml to aid contributions
